### PR TITLE
fix: 227/support pre-encoded urls

### DIFF
--- a/lib/config/configure.js
+++ b/lib/config/configure.js
@@ -78,7 +78,7 @@ module.exports = _.curry((rascalConfig, next) => {
     const connectionAttributes = _.defaultsDeep({}, attributesFromUrl, attributesFromConfig, defaults);
 
     setConnectionAttributes(connection, connectionAttributes);
-    setConnectionUrls(connection);
+    setConnectionUrls(connection, vhostConfig.connection.options.preEncoded);
     setConnectionIndex(connection, vhostConfig.connectionStrategy, index);
 
     configureManagementConnection(vhostConfig, vhostName, connection);
@@ -116,13 +116,18 @@ module.exports = _.curry((rascalConfig, next) => {
     _.defaultsDeep(connection, attributes, defaults);
   }
 
-  function setConnectionUrls(connection) {
+  function setConnectionUrls(connection, preEncoded) {
+    preEncoded = preEncoded || {};
     const auth = getAuth(connection.user, connection.password);
     const pathname = connection.vhost === '/' ? '' : connection.vhost;
     const query = connection.options;
 
     connection.url = url.format({
-      slashes: true, ...connection, auth, pathname, query,
+      slashes: true,
+      ...connection,
+      auth: preEncoded.auth ? decodeURIComponent(auth) : auth,
+      pathname: preEncoded.pathname ? decodeURIComponent(pathname) : pathname,
+      query: preEncoded.query ? decodeURIComponent(query) : query,
     });
     connection.loggableUrl = connection.url.replace(/:[^:]*@/, ':***@');
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Create a new config option to allow consumers to "inform" rascal about the url configured, specifically which parts of it are pre-encoded.

## Description
<!--- Describe your changes in detail -->
the PR is small enough to understand, I think

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[227](https://github.com/onebeyond/rascal/issues/227)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
see issue

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
If you like this approach, I'll look into how to write a unit test. I've tested it from my fork in my working project.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
