### PR TITLE
perf(backoff): optimize linear backoff using closure

### DIFF
--- a/lib/backoff/linear.js
+++ b/lib/backoff/linear.js
@@ -1,18 +1,11 @@
-const get = require('lodash').get;
-
-module.exports = function (options) {
-  const min = get(options, 'min', 1000);
-  const max = get(options, 'max', min);
+module.exports = function (options = {}) {
+  const min = options.min || 1000;
+  const max = options.max || min;
+  const range = max - min;
 
   function next() {
-    return Math.floor(Math.random() * (max - min + 1) + min);
+    return range === 0 ? min : Math.floor(Math.random() * (range + 1) + min);
   }
 
-  // eslint-disable-next-line no-empty-function
-  function reset() {}
-
-  return {
-    next,
-    reset,
-  };
+  return { next, reset: () => {} };
 };


### PR DESCRIPTION
Remove lodash dependency for faster property access
Pre-calculate range in closure to avoid repeated subtraction on each call
Add early return optimization for constant values (min === max)
-Use modern JS features (default parameters, arrow functions)

The range calculation is moved from the hot path (next() function) to
the closure scope, ensuring it's computed only once when the backoff
function is created rather than on every invocation